### PR TITLE
Fix error with iterkeys

### DIFF
--- a/BLEHeartRateLogger.py
+++ b/BLEHeartRateLogger.py
@@ -54,7 +54,7 @@ def parse_args():
         # configuration of the parser.
         args = vars(parser.parse_args([]))
         err = False
-        for key in config.iterkeys():
+        for key in config.keys():
             if key not in args:
                 log.error("Configuration file error: invalid key '" + key + "'.")
                 err = True


### PR DESCRIPTION
Fixes 
"bt_heartratelogger/BLEHeartRateLogger.py", line 57, in parse_args
    for key in config.iterkeys():
AttributeError: 'dict' object has no attribute 'iterkeys'"